### PR TITLE
Add files via upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 See https://yuneecpilots.com/threads/typhoon-h-480-px4-v1-10-stability-issues.18205/ for more information
 
 Latest flight-tested binary: https://github.com/tonirosendahl/Thunderbird/raw/Typhoon_H_480/Thunderbird_170521_FT_LATEST.zip
+Recommended version is still the: https://github.com/tonirosendahl/Thunderbird/blob/Typhoon_H_480/Thunderbird_030420_CD.zip
 
 Latest documentation by h-elsner: https://github.com/h-elsner/Thunderbird/tree/Typhoon_H_480/Documentation
 


### PR DESCRIPTION
I added a new way of flashing the board of the typhoon h with a generic board since the nucleo is not anymore available. I can add description if it helps with my wiring. 

I found a error in the manual too. On the page 5 the 3 mode is with the basic config rth no ? not mission mode.

For the read me maybe say that the recommended version is the https://github.com/tonirosendahl/Thunderbird/blob/Typhoon_H_480/Thunderbird_030420_CD.zip since you found bugs in the newest 